### PR TITLE
Fixed unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,7 @@ android {
         versionCode 18
         versionName "3.2"
         testApplicationId "com.readtracker.android.test"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     lintOptions {
@@ -96,8 +97,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.2.0'
+    compile 'com.android.support:support-v4:23.2.0'
     compile 'com.j256.ormlite:ormlite-android:4.48'
     compile 'com.j256.ormlite:ormlite-core:4.48'
     compile 'com.squareup.picasso:picasso:2.2.0'
@@ -106,4 +107,5 @@ dependencies {
     compile files('lib/annotations.jar')
     testCompile 'org.skyscreamer:jsonassert:1.2.3'
     testCompile 'junit:junit:4.12'
+    testCompile "org.robolectric:robolectric:3.0"
 }

--- a/app/src/test/java/com/readtracker/android/db/MigrationTests.java
+++ b/app/src/test/java/com/readtracker/android/db/MigrationTests.java
@@ -1,47 +1,45 @@
 package com.readtracker.android.db;
 
-import android.content.Context;
-import android.test.mock.MockContext;
-
 import com.readtracker.android.test_support.DatabaseTestCase;
 import com.readtracker.android.test_support.TestUtils;
 
 import junit.framework.Assert;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
 import java.util.List;
 
 public class MigrationTests extends DatabaseTestCase {
 
-  @Override protected DatabaseHelper createDatabaseHelper() {
+  @Ignore
+  public DatabaseHelper createDatabaseHelper() {
     int migrationStartVersion = 11;
-    Context context = new MockContext();
-    setContext(context);
-    Assert.assertNotNull(context);
-    return new DatabaseHelper(context, DATABASE_NAME, null, migrationStartVersion);
+    Assert.assertNotNull(getContext());
+    return new DatabaseHelper(getContext(), DATABASE_NAME, null, migrationStartVersion);
   }
 
+  @Test
   public void test_migration_12() {
-    //@TODO: Investigate why does the migration test fail since the update to the new testing framework
-//    Book book = TestUtils.buildRandomBook();
-//    getDatabaseManager().save(book);
-//
-//    Session brokenSession = new Session();
-//    brokenSession.setTimestampMs(11158586000L /* Sun, 10 May 1970 03:36:26 GMT, ms */);
-//    brokenSession.setBook(book);
-//    getDatabaseManager().save(brokenSession);
-//
-//    Session probablyOkSession = new Session();
-//    probablyOkSession.setTimestampMs(894771386000L /* Sun, 10 May 1998 03:36:26 GMT, ms */);
-//    probablyOkSession.setBook(book);
-//    getDatabaseManager().save(probablyOkSession);
-//
-//    DatabaseHelper.migrateVersion31Sessions(getDatabaseManager());
-//
-//    List<Session> session = getDatabaseManager().getAll(Session.class);
-//    assertEquals(2, session.size());
-//    final long THRESHOLD_DATE = 31536000000L /* Fri, 01 Jan 1971 00:00:00 GMT */;
-//    assertTrue(session.get(0).getTimestampMs() >= THRESHOLD_DATE);
-//    assertTrue(session.get(1).getTimestampMs() >= THRESHOLD_DATE);
-    assertTrue(true);
+    Book book = TestUtils.buildRandomBook();
+    getDatabaseManager().save(book);
+
+    Session brokenSession = new Session();
+    brokenSession.setTimestampMs(11158586000L /* Sun, 10 May 1970 03:36:26 GMT, ms */);
+    brokenSession.setBook(book);
+    getDatabaseManager().save(brokenSession);
+
+    Session probablyOkSession = new Session();
+    probablyOkSession.setTimestampMs(894771386000L /* Sun, 10 May 1998 03:36:26 GMT, ms */);
+    probablyOkSession.setBook(book);
+    getDatabaseManager().save(probablyOkSession);
+
+    DatabaseHelper.migrateVersion31Sessions(getDatabaseManager());
+
+    List<Session> session = getDatabaseManager().getAll(Session.class);
+    assertEquals(2, session.size());
+    final long THRESHOLD_DATE = 31536000000L /* Fri, 01 Jan 1971 00:00:00 GMT */;
+    assertTrue(session.get(0).getTimestampMs() >= THRESHOLD_DATE);
+    assertTrue(session.get(1).getTimestampMs() >= THRESHOLD_DATE);
   }
 }

--- a/app/src/test/java/com/readtracker/android/db/export/JSONExporter_exportCompleteBook.java
+++ b/app/src/test/java/com/readtracker/android/db/export/JSONExporter_exportCompleteBook.java
@@ -8,6 +8,7 @@ import com.readtracker.android.test_support.DatabaseTestCase;
 import com.readtracker.android.test_support.TestUtils;
 
 import org.json.JSONObject;
+import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
@@ -25,6 +26,7 @@ public class JSONExporter_exportCompleteBook extends DatabaseTestCase {
     return new JSONExporter(getDatabaseManager());
   }
 
+  @Test
   public void test_export_populated_book() throws Exception {
     List<Book> books = populateBooksForExpectedOutput();
 
@@ -35,6 +37,7 @@ public class JSONExporter_exportCompleteBook extends DatabaseTestCase {
     JSONAssert.assertEquals(expected, actual, true);
   }
 
+  @Test
   // Similar to export_all_books, but tests the write out to disk
   public void test_export_to_disk() throws Exception {
     List<Book> books = populateBooksForExpectedOutput();

--- a/app/src/test/java/com/readtracker/android/db/export/JSONImporter_importData.java
+++ b/app/src/test/java/com/readtracker/android/db/export/JSONImporter_importData.java
@@ -11,6 +11,11 @@ import com.readtracker.android.test_support.TestUtils;
 
 import junit.framework.Assert;
 
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -20,10 +25,13 @@ import java.util.List;
 import static com.readtracker.android.test_support.TestUtils.randomString;
 
 public class JSONImporter_importData extends DatabaseTestCase {
+
   private JSONImporter getImporter() {
     return new JSONImporter(getDatabaseManager());
   }
 
+
+  @Test
   public void test_import_version_1_file() throws Exception, ImportException {
     File fileToImport = _copyResourceFile("export_version_1.json");
 
@@ -33,6 +41,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
     _assertImportedBooks();
   }
 
+  @Test
   public void test_import_version_2_file() throws Exception, ImportException {
     File fileToImport = _copyResourceFile("export_version_2.json");
 
@@ -42,6 +51,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
     _assertImportedBooks();
   }
 
+  @Test
   public void test_import_with_no_merge_conflict() throws Exception, ImportException {
     Book bookToImport = TestUtils.buildBook("постои конфликт", "авторот", 200);
     File fileToImport = _createExportFileForBooks(Arrays.asList(bookToImport));
@@ -58,6 +68,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
     assertFalse(books.get(0).getTitle().equals(books.get(1).getTitle()));
   }
 
+  @Test
   public void test_import_with_simple_merge_conflict() throws Exception, ImportException {
     Book existing = TestUtils.buildBook("Metamorphosis", "Franz Kafka", 200);
     getDatabaseManager().save(existing);
@@ -80,6 +91,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
     assertEquals(300f, bookAfterImport.getPageCount());
   }
 
+  @Test
   public void test_import_with_nested_merge_conflicts() throws Exception, ImportException {
     // Create a book in the database that we later want to import
     Book imported = TestUtils.buildBook("Metamorphosis", "Franz Kafka", 200);
@@ -134,7 +146,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
   }
 
   private File _createExportFileForBooks(List<Book> books) throws Exception {
-    Context context = new MockContext();
+    Context context = getContext();
     setContext(context);
     Assert.assertNotNull(context);
     File exportFile = new File(context.getFilesDir(), randomString());
@@ -156,7 +168,7 @@ public class JSONImporter_importData extends DatabaseTestCase {
   }
 
   private File _copyResourceFile(String resourcePath) throws IOException {
-    Context context = new MockContext();
+    Context context = getContext();
     setContext(context);
     Assert.assertNotNull(context);
     File exportFile = new File(context.getFilesDir(), randomString());

--- a/app/src/test/java/com/readtracker/android/test_support/DatabaseTestCase.java
+++ b/app/src/test/java/com/readtracker/android/test_support/DatabaseTestCase.java
@@ -2,50 +2,61 @@ package com.readtracker.android.test_support;
 
 import android.content.Context;
 import android.test.AndroidTestCase;
-import android.test.mock.MockContext;
 
 import com.readtracker.android.db.DatabaseHelper;
 import com.readtracker.android.db.DatabaseManager;
 
-import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest=Config.NONE)
+@Ignore
 public class DatabaseTestCase extends AndroidTestCase {
   public final static String DATABASE_NAME = "readtracker-test.db";
   public static int DATABASE_VERSION = DatabaseHelper.DATABASE_VERSION;
 
   private DatabaseManager mDatabaseManager;
   private DatabaseHelper mDatabaseHelper;
-  Context context;
+  private Context context;
 
+  @Before
+  public void setUp() throws Exception {
 
-  @Override protected void setUp() throws Exception {
-    super.setUp();
-    context = new MockContext();
+    context = RuntimeEnvironment.application;
     setContext(context);
-    Assert.assertNotNull(context);
 
     mDatabaseHelper = createDatabaseHelper();
     deleteDatabase();
-    mDatabaseManager = new DatabaseManager(mDatabaseHelper);
+    mDatabaseManager = new DatabaseManager(getDatabaseHelper());
   }
 
-  @Override protected void tearDown() throws Exception {
-    super.tearDown();
+  @After
+  public void tearDown() throws Exception {
     deleteDatabase();
   }
 
+  @Ignore
   protected DatabaseHelper createDatabaseHelper() {
-    return new DatabaseHelper(context, DATABASE_NAME, null, DATABASE_VERSION);
+    return new DatabaseHelper(getContext(), DATABASE_NAME, null, DATABASE_VERSION);
   }
 
+  @Ignore
   protected void deleteDatabase() {
     context.deleteDatabase(DATABASE_NAME);
   }
 
+  @Ignore
   protected DatabaseManager getDatabaseManager() {
     return mDatabaseManager;
   }
 
+  @Ignore
   protected DatabaseHelper getDatabaseHelper() {
     return mDatabaseHelper;
   }


### PR DESCRIPTION
Fixed the unit tests by adding roboelectric to mock context.

With the new Android test framework, unit tests are separated from functional UI tests:
- test -> contains all unit tests and ran by travis using this line: ```./gradlew clean test --stacktrace```
- androidTest -> will contain all UI tests and can be run by the line: ```./gradlew build connectedAndroidTest``` once they are implemented.

Will start working on adding UI tests but will separate that into a new branch. 

@christoffer Would be nice if you would go over this and accept it once you reviewed!

Will continue doing this going forward.