### PR TITLE
Fix issue with export files being removed on uninstall

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,9 +141,10 @@
     <string name="settings_export_confirmation">This will export all your data to a JSON file.\n\nThe file is saved in your Downloads folder, where it can be shared, viewed, or imported back into ReadTracker.</string>
     <string name="settings_export_positive_button">Export</string>
     <string name="settings_export_failed">Unfortunately there was an unexpected error when exporting your data. Make sure your external media is available and try again.</string>
-    <string name="settings_export_share_file">Do you want to share the file to an app or person?</string>
+    <string name="settings_export_share_file">The export completed successfully and the file is now in your Downloads folder.\n\nDo you want to share the file directly to an app or person?\n\nThe file will remain in your Downloads folder.</string>
     <string name="settings_export_need_external_media">Please make sure that your external media is mounted before exporting your ReadTracker data.</string>
-    <string name="settings_export_success">Successfully exported your ReadTracker data to the Downloads folder.</string>
+    <string name="settings_export_success">Successfully exported ReadTracker data</string>
+    <string name="settings_share_export">Share exported file</string>
     <string name="settings_title_settings">Settings</string>
     <string name="settings_title_data">Data</string>
     <string name="settings_title_about">About</string>


### PR DESCRIPTION
Turns out that Android, starting from Lollipop, deletes any files downloaded by an app when it's uninstalled. Since we since 3.2 started registering the exported files with the Download manager (in an attempt to make it easier to find the files), they are now deleted when the app is uninstalled.

This has the potential to be catastrophic if the user decides to uninstall the app, but wants to export the data as a backup first, as the export will be irreversibly removed as well.

This fixes the issue by writing the file to the Downloads folder, but reverts to the old behavior of showing a share intent to allow the user to act on the file conveniently instead of registering it with the DownloadManager.

Tested by exporting file, and uninstalling the app and verifying that the export was still there. 
